### PR TITLE
Add initial Cargo.toml, gitignore, README, and rust lib file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "snp"
+version = "0.1.0"
+authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
+edition = "2018"
+homepage = "https://github.com/enarx/snp"
+repository = "https://github.com/enarx/snp"
+description = "Library for AMD SEV-SNP"
+readme = "README.md"
+keywords = ["amd", "snp"]
+categories = ["os", "os::linux-apis", "parsing", "network-programming", "hardware-support"]
+exclude = [ ".gitignore", ".github/*" ]
+
+[badges]
+# See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
+github = { repository = "enarx/snp", workflow = "test" }
+#github = { repository = "enarx/snp", workflow = "lint" }
+maintenance = { status = "actively-developed" }
+is-it-maintained-issue-resolution = { repository = "enarx/snp" }
+is-it-maintained-open-issues = { repository = "enarx/snp" }
+
+[features]
+default = []
+hw_tests = []
+dangerous_hw_tests = ["hw_tests"]
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# snp
+Library for AMD SEV-SNP

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Initial files using enarx/sev as a reference. Just a note: I inputted Nathaniel's name in the Cargo.toml authors section as I assumed he would be the main contact regarding Enarx-related SNP questions.